### PR TITLE
Remote Debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
       "justMyCode": true
     },
     {
-      "name": "Django LAN Debugger",
+      "name": "LAN Debugger",
       "type": "debugpy",
       "request": "launch",
       "program": "${workspaceFolder}\\manage.py",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,18 +1,28 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-      {
-        "name": "Python Debugger: Django",
-        "type": "debugpy",
-        "request": "launch",
-        "program": "${workspaceFolder}\\manage.py",
-        "python": "${workspaceFolder}\\.venv\\Scripts\\python.exe",
-        "args": ["runserver"],
-        "django": true,
-        "justMyCode": true
-      }
-    ]
-  }
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python Debugger: Django",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}\\manage.py",
+      "python": "${workspaceFolder}\\.venv\\Scripts\\python.exe",
+      "args": ["runserver"],
+      "django": true,
+      "justMyCode": true
+    },
+    {
+      "name": "Django LAN Debugger",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}\\manage.py",
+      "python": "${workspaceFolder}\\.venv\\Scripts\\python.exe",
+      "args": ["runserver", "0.0.0.0:80", "--settings=IFC.settings_LAN"],
+      "django": true,
+      "justMyCode": true
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Python Debugger: Django",
+      "name": "Loopback Debugger",
       "type": "debugpy",
       "request": "launch",
       "program": "${workspaceFolder}\\manage.py",

--- a/IFC/settings_LAN.py
+++ b/IFC/settings_LAN.py
@@ -1,0 +1,3 @@
+from IFC.settings import *
+
+ALLOWED_HOSTS = ['*']

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 An RCOS project used for club websites at RPI
 
 # Setup
-To setup the project's development environment, run setup.bat.
-This performs all necessary first-time setup tasks and adds a VSCode debugger config for running the server in debug mode.
+On windows, the first-time setup process can be performed completely by running the included setup.bat script.
 
 # Starting the server
-To start the server in debug mode with VSCode, select Run -> Start Debugging.
-To start the server normally, run `.venv\scripts\python.exe manage.py runserver`.
+This repo comes with two VSCode launch configs; one for local device testing only (Loopback Debugger), and another for testing on remote clients (LAN Debugger). Note that the LAN Debugger binds to all available adapters, not just the local area network.
+
+To launch one of the predefined VSCode configs, navigate to 'Run & Debug' in the left sidebar, and then select a config.
+To start the server normally, run `.venv\scripts\python.exe manage.py runserver`. Remember to use the venv when launching the server, and not your system's python installation!

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An RCOS project used for club websites at RPI
 On windows, the first-time setup process can be performed completely by running the included setup.bat script.
 
 # Starting the server
-This repo comes with two VSCode launch configs; one for local device testing only (Loopback Debugger), and another for testing on remote clients (LAN Debugger). Note that the LAN Debugger binds to all available adapters, not just the local area network.
+This repo comes with two VSCode launch configs; one for local device testing only (Loopback Debugger), and another for testing on remote clients (LAN Debugger). Note that the LAN Debugger binds to all available adapters, including but not limited to loopback and LAN.
 
 To launch one of the predefined VSCode configs, navigate to 'Run & Debug' in the left sidebar, and then select a config.
 To start the server normally, run `.venv\scripts\python.exe manage.py runserver`. Remember to use the venv when launching the server, and not your system's python installation!


### PR DESCRIPTION
By default, django only binds to loopback (localhost), which makes it impossible to test on mobile devices or other remote clients. This PR adds a second launch config in VSCode called "LAN Debugger". This binds to all available network interfaces and allows all hostnames.

Implements #20 