### PR TITLE
Add signup link to login page

### DIFF
--- a/FSC/templates/FSC/login.html
+++ b/FSC/templates/FSC/login.html
@@ -24,5 +24,6 @@
         <div class="form-group">
             <button type="submit"><span style="font-weight: bold;">Log in</span></button>
         </div>
+        <a href="/signup">Create account</a>
     </form>
 {% endblock %}


### PR DESCRIPTION
Fixes #28 
From the login page, users can click the link under the login button to navigate to the signup page.