### PR TITLE
Separate chapters by council

### DIFF
--- a/FSC/templates/FSC/ourChapters.html
+++ b/FSC/templates/FSC/ourChapters.html
@@ -75,19 +75,53 @@
             position: flex;
         }
         
-        .chapters{margin-top: 25px;}
+        .council-header {
+            font-size: 50px;
+            width: 1000px;
+            text-align: center;
+        }
     </style>
 
     <div class="chapters">
         {% load static %}
-<div class="container">
-  {% for chapter in chapters %}
-    <a href="{{ chapter.name }}" class="button brighten">
-      <img src="{{ chapter.image.url }}" alt="{{ chapter.name }}">
-      <p>{{chapter.name}}</p>
-      <p class="nickname">{{chapter.letters}}</p>
-    </a>
-  {% endfor %}
-</div>
+        <div class="container">
+            <div class="council-header">
+                <span>IFC</span>
+                <hr>
+            </div>
+            {% for chapter in ifc_chapters %}
+                <a href="{{ chapter.name }}" class="button brighten">
+                <img src="{{ chapter.image.url }}" alt="{{ chapter.name }}">
+                <p>{{chapter.name}}</p>
+                <p class="nickname">{{chapter.letters}}</p>
+                </a>
+            {% endfor %}
+        </div>
+        <div class="container">
+            <div class="council-header">
+                <span>MSFC</span>
+                <hr>
+            </div>
+            {% for chapter in msfc_chapters %}
+                <a href="{{ chapter.name }}" class="button brighten">
+                <img src="{{ chapter.image.url }}" alt="{{ chapter.name }}">
+                <p>{{chapter.name}}</p>
+                <p class="nickname">{{chapter.letters}}</p>
+                </a>
+            {% endfor %}
+        </div>
+        <div class="container">
+            <div class="council-header">
+                <span>Panhellenic</span>
+                <hr>
+            </div>
+            {% for chapter in panhel_chapters %}
+                <a href="{{ chapter.name }}" class="button brighten">
+                <img src="{{ chapter.image.url }}" alt="{{ chapter.name }}">
+                <p>{{chapter.name}}</p>
+                <p class="nickname">{{chapter.letters}}</p>
+                </a>
+            {% endfor %}
+        </div>
     </div> 
 {% endblock %}

--- a/FSC/templates/FSC/ourChapters.html
+++ b/FSC/templates/FSC/ourChapters.html
@@ -123,5 +123,18 @@
                 </a>
             {% endfor %}
         </div>
+        <div class="container">
+            <div class="council-header">
+                <span>Professional Fraternities & Sororities</span>
+                <hr>
+            </div>
+            {% for chapter in pfs_chapters %}
+                <a href="{{ chapter.name }}" class="button brighten">
+                <img src="{{ chapter.image.url }}" alt="{{ chapter.name }}">
+                <p>{{chapter.name}}</p>
+                <p class="nickname">{{chapter.letters}}</p>
+                </a>
+            {% endfor %}
+        </div>
     </div> 
 {% endblock %}

--- a/FSC/views.py
+++ b/FSC/views.py
@@ -20,8 +20,10 @@ def simpleView(template):
 
 # Requesting Webpages:
 def ourChapters(request):
-    chapters = Chapter.objects.all()
-    return render(request, 'FSC/ourChapters.html', {'chapters': chapters})
+    ifc_chapters = sorted(Chapter.objects.filter(council="ifc"), key=lambda ch: ch.name)
+    panhel_chapters = sorted(Chapter.objects.filter(council="panhel"), key=lambda ch: ch.name)
+    msfc_chapters = sorted(Chapter.objects.filter(council="msfc"), key=lambda ch: ch.name)
+    return render(request, 'FSC/ourChapters.html', {'ifc_chapters': ifc_chapters, "panhel_chapters": panhel_chapters, "msfc_chapters": msfc_chapters})
 
 
 def select_chapter(request):

--- a/FSC/views.py
+++ b/FSC/views.py
@@ -23,7 +23,8 @@ def ourChapters(request):
     ifc_chapters = sorted(Chapter.objects.filter(council="ifc"), key=lambda ch: ch.name)
     panhel_chapters = sorted(Chapter.objects.filter(council="panhel"), key=lambda ch: ch.name)
     msfc_chapters = sorted(Chapter.objects.filter(council="msfc"), key=lambda ch: ch.name)
-    return render(request, 'FSC/ourChapters.html', {'ifc_chapters': ifc_chapters, "panhel_chapters": panhel_chapters, "msfc_chapters": msfc_chapters})
+    pfs_chapters = sorted(Chapter.objects.filter(council="pfs"), key=lambda ch: ch.name)
+    return render(request, 'FSC/ourChapters.html', {'ifc_chapters': ifc_chapters, "panhel_chapters": panhel_chapters, "msfc_chapters": msfc_chapters, 'pfs_chapters': pfs_chapters})
 
 
 def select_chapter(request):


### PR DESCRIPTION
Fixes #9 
Organizes chapters by council on the chapter grid page, and sorts them alphabetically within each council. Councils currently include IFC, Panhel, and MSFC 